### PR TITLE
ci: trigger publish on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,17 +1,14 @@
 name: Publish Python 🐍 distribution 📦 to PyPI
 
 on:
-  workflow_run:  # zizmor: ignore[dangerous-triggers]
-    workflows:
-      - Bump version
-    types:
-      - completed
+  push:
+    tags:
+      - "*"
 
 permissions: {}
 
 jobs:
   build:
-    if: "startsWith(github.event.head_commit.message, 'bump:')"
     name: Build distribution 📦
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Switches `publish.yml` from a `workflow_run`-triggered job (gated by a `bump:` commit-message check) to the standard `push: tags: ['*']` pattern.
- Fixes the bug where the publish job was skipped after the 0.2.0 bump because `github.event.head_commit.message` on a `workflow_run` event references the merge commit (`Merge pull request #2…`), not the new bump commit.

## Changes
- `.github/workflows/publish.yml`: replace `workflow_run` trigger with `push: tags: ["*"]`; remove the now-redundant `if: startsWith(..., 'bump:')` condition on the `build` job; drop the inline zizmor ignore for `dangerous-triggers` (no longer applicable).