### PR TITLE
chore: rename package to uv-audit2 for PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,15 @@ uv-audit -r pyproject.toml --all --json | jq -r '.inputs[].vulnerabilities[].id'
 
 ## Install as a uv tool
 
-1. Install: `uv tool install git+https://github.com/SpielerNogard/uv-audit.git@main`
-2. Run: `uv tool run uv-audit -r requirements.txt` or `uv audit -r requirements.txt`
+From PyPI (package name is `uv-audit2`, CLI command stays `uv-audit`):
+```
+uv tool install uv-audit2
+uv-audit -r requirements.txt
+```
+
+Or directly from git:
+```
+uv tool install git+https://github.com/SpielerNogard/uv-audit.git@main
+uv tool run uv-audit -r requirements.txt
+```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "uv-audit"
+name = "uv-audit2"
 version = "0.2.0"
 description = "A pip-audit like tool for auditing Python packages in requirements files."
 authors = [


### PR DESCRIPTION
## Summary
- Renames the PyPI distribution from `uv-audit` to `uv-audit2` because the original name on PyPI is taken and the trusted-publisher token is scoped to `uv-audit2`.
- CLI command name stays `uv-audit` so existing GitHub Action workflow scripts and user habits continue to work unchanged.
- Updates README to mention the new install command (`uv tool install uv-audit2`).

## Changes
- `pyproject.toml`: `[project].name` set to `uv-audit2`
- `README.md`: install instructions show the PyPI name explicitly