### PR TITLE
fix(ci): use BUMP_TOKEN PAT so tag-push triggers publish

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Check out
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          token: ${{ secrets.BUMP_TOKEN }}
+          token: ${{ secrets.BUMP_TOKEN }} # zizmor: ignore[secrets-outside-env]
           fetch-depth: 0
           persist-credentials: false
       - name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@338bbd841b75aaee6bf5340e1fa12f6ab58ff9ff  # master
         with:
-          github_token: ${{ secrets.BUMP_TOKEN }}
+          github_token: ${{ secrets.BUMP_TOKEN }} # zizmor: ignore[secrets-outside-env]

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Check out
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          token: "${{ secrets.GITHUB_TOKEN }}"
+          token: ${{ secrets.BUMP_TOKEN }}
           fetch-depth: 0
           persist-credentials: false
       - name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@338bbd841b75aaee6bf5340e1fa12f6ab58ff9ff  # master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.BUMP_TOKEN }}


### PR DESCRIPTION
## Summary
- Switch `bump.yml` from the default `GITHUB_TOKEN` to the `BUMP_TOKEN` secret (fine-grained PAT with `Contents: write` on this repo).

## Why
The default `GITHUB_TOKEN` does not trigger downstream workflows by design (anti-loop). When the previous bump pushed the `0.3.0` tag, `publish.yml` therefore did not fire — we had to re-push the tag manually to get a PyPI release.

A PAT (or deploy key) is the standard workaround. With `BUMP_TOKEN`, the tag created by `cz bump` is treated as a normal external push, and `publish.yml` triggers automatically.

## Changes
- `.github/workflows/bump.yml`: both `token:` and `github_token:` now read `secrets.BUMP_TOKEN`.

## Test plan
- After merge, the next conventional commit on `main` triggers `bump.yml`. Confirm in the run that:
  - the bump commit and tag push succeed,
  - `publish.yml` starts automatically on the tag push (no manual re-push needed).